### PR TITLE
zen3: lower required GCC version to 10.3.0

### DIFF
--- a/more-uarches-for-kernel-5.8+.patch
+++ b/more-uarches-for-kernel-5.8+.patch
@@ -221,7 +221,7 @@ index 814fe0d349b0..a79ff6379479 100644
 +
 +config MZEN3
 +	bool "AMD Zen 3"
-+	depends on GCC_VERSION > 110000
++	depends on GCC_VERSION > 100300
 +	help
 +	  Select this for AMD Family 19h Zen 3 processors.
 +


### PR DESCRIPTION
Zen 3 tuning has been backported to the upcoming GCC v10.3.0 release.

Link: https://www.phoronix.com/scan.php?page=news_item&px=Znver3-GCC-10-Backport

Signed-off-by: Oleksandr Natalenko <oleksandr@natalenko.name>